### PR TITLE
add: Enable interactive sessions for `exec` and `run` via `stdio: 'inherit'`

### DIFF
--- a/commands/exec.js
+++ b/commands/exec.js
@@ -1,5 +1,6 @@
-const compose = require('docker-compose');
+// const compose = require('docker-compose');
 const withComposeConfig = require('../docker/withComposeConfig');
+const execComposeWithTTY = require('../docker/execComposeWithTTY');
 
 /**
  * exec - execs a command in a container
@@ -8,6 +9,11 @@ const withComposeConfig = require('../docker/withComposeConfig');
  * @return {void}
  */
 function exec(args) {
-  withComposeConfig(args, (config) => compose.exec(args.container, args['--'], config));
+  withComposeConfig(args, (config) => {
+    const cmdArgs = [args.container].concat(args['--']);
+    // console.log(config);
+    // return compose.exec(args.container, args['--'], config);
+    return execComposeWithTTY('exec', cmdArgs, config);
+  });
 }
 module.exports = exec;

--- a/commands/exec.js
+++ b/commands/exec.js
@@ -1,4 +1,3 @@
-// const compose = require('docker-compose');
 const withComposeConfig = require('../docker/withComposeConfig');
 const execComposeWithTTY = require('../docker/execComposeWithTTY');
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -1,4 +1,3 @@
-const compose = require('docker-compose');
 const withComposeConfig = require('../docker/withComposeConfig');
 const execComposeWithTTY = require('../docker/execComposeWithTTY');
 

--- a/commands/run.js
+++ b/commands/run.js
@@ -1,5 +1,6 @@
 const compose = require('docker-compose');
 const withComposeConfig = require('../docker/withComposeConfig');
+const execComposeWithTTY = require('../docker/execComposeWithTTY');
 
 /**
  * run - runs a command in a container
@@ -10,7 +11,8 @@ const withComposeConfig = require('../docker/withComposeConfig');
 function run(args) {
   withComposeConfig(args, (config) => {
     config.commandOptions.push('--rm');
-    return compose.run(args.container, args['--'], config);
+    const cmdArgs = [args.container].concat(args['--']);
+    return execComposeWithTTY('run', cmdArgs, config);
   });
 }
 module.exports = run;

--- a/docker/execComposeWithTTY/composeOptionsToArgs.js
+++ b/docker/execComposeWithTTY/composeOptionsToArgs.js
@@ -1,0 +1,21 @@
+/**
+ * composeOptionsToArgs - Taken from https://github.com/PDMLab/docker-compose/blob/05ba0fa5a838675ce9755d3559a55910b5e4dbae/src/index.ts#L140
+ * Converts docker-compose commandline options to cli arguments
+ *
+ * @param  {array} composeOptions description
+ * @return {array}
+ */
+function composeOptionsToArgs(composeOptions) {
+  let composeArgs = [];
+
+  composeOptions.forEach((option) => {
+    if (option instanceof Array) {
+      composeArgs = composeArgs.concat(option);
+    }
+    if (typeof option === 'string') {
+      composeArgs = composeArgs.concat([option]);
+    }
+  });
+  return composeArgs;
+}
+module.exports = composeOptionsToArgs;

--- a/docker/execComposeWithTTY/configToArgs.js
+++ b/docker/execComposeWithTTY/configToArgs.js
@@ -1,0 +1,22 @@
+/**
+ * configToArgs - Taken from https://github.com/PDMLab/docker-compose/blob/05ba0fa5a838675ce9755d3559a55910b5e4dbae/src/index.ts#L123
+ * Converts supplied yml files to cli arguments
+ * https://docs.docker.com/compose/reference/overview/#use--f-to-specify-name-and-path-of-one-or-more-compose-files
+ *
+ * @param  {array|string} config the config
+ * @return {array}
+ */
+function configToArgs(config) {
+  if (typeof config === 'undefined') {
+    return [];
+  } if (typeof config === 'string') {
+    return ['-f', config];
+  } if (config instanceof Array) {
+    return config.reduce(
+      (args, item) => args.concat(['-f', item]),
+      [],
+    );
+  }
+  throw new Error(`Invalid argument supplied: ${config}`);
+}
+module.exports = configToArgs;

--- a/docker/execComposeWithTTY/index.js
+++ b/docker/execComposeWithTTY/index.js
@@ -1,0 +1,53 @@
+const childProcess = require('child_process');
+const configToArgs = require('./configToArgs');
+const composeOptionsToArgs = require('./composeOptionsToArgs');
+
+/**
+ * execComposeWithTTY - execute a compose command while attaching
+ * the host tty
+ *
+ * @param  {string} command the command to execute (most of the time you want 'exec' or 'run')
+ * @param  {array}  args    args for the command
+ * @param  {array}  options options for the command
+ * @return {Promise}
+ */
+function execComposeWithTTY(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const composeOptions = options.composeOptions || [];
+    const commandOptions = options.commandOptions || [];
+    let composeArgs = composeOptionsToArgs(composeOptions);
+    const isConfigProvidedAsString = !!options.configAsString;
+
+    const configArgs = isConfigProvidedAsString
+      ? ['-f', '-']
+      : configToArgs(options.config);
+
+    composeArgs = composeArgs.concat(
+      configArgs.concat(
+        [command].concat(composeOptionsToArgs(commandOptions), args),
+      ),
+    );
+
+    const { cwd } = options;
+    const env = options.env || undefined;
+    const executablePath = options.executablePath || 'docker-compose';
+
+    const childProc = childProcess.spawn(executablePath, composeArgs, {
+      cwd,
+      env,
+      stdio: 'inherit',
+    });
+
+    childProc.on('error', (err) => {
+      reject(err);
+    });
+    childProc.on('exit', (exitCode) => {
+      if (exitCode === 0) {
+        resolve(exitCode);
+      } else {
+        reject(exitCode);
+      }
+    });
+  });
+}
+module.exports = execComposeWithTTY;

--- a/docker/withComposeConfig.js
+++ b/docker/withComposeConfig.js
@@ -23,7 +23,7 @@ const getComposeConfig = require('./getComposeConfig');
 async function withComposeConfig(args, callback) {
   const rootComposeFile = getRootComposeFile(args);
   const config = getComposeConfig(args, rootComposeFile);
-  await callback(config).catch((error) => error);
+  await callback(config).catch((error) => console.error(error)); // eslint-disable-line no-console
   // console.log(error); // eslint-disable-line no-console
   // console.log('\nThere was an error. You can find more information in the
   // output above \n'); // eslint-disable-line no-console


### PR DESCRIPTION
This PR addds interactive session support for `ssdev exec -- ...` and `ssdev run -- ...`.

This is a crucial feature with the upcoming changes including a composer installation in the default container.