### PR TITLE
Fix: Passwort authentication plugin

### DIFF
--- a/docker/getRootComposeFile/defaultComposeContent.js
+++ b/docker/getRootComposeFile/defaultComposeContent.js
@@ -36,7 +36,7 @@ module.exports = (args) => ({
         target: '/var/lib/mysql',
       }],
       command: [
-        '--default-authentication-plugin=mysql_native_password',
+        '--mysql-native-password=ON',
       ],
     },
     // composer: {


### PR DESCRIPTION
The `mysql_native_password` plugin was deprecated in 8.0.34, is disabled as of 8.4, and will be removed completely beginning from mySQL 9.0. 

Due to the disabling, the plugin cannot be loaded under 8.4 using `default-authentication-plugin` and must instead be re-enabled using the `--mysql-native-password=ON` argument.

> MySQL native password authentication changes.  Beginning with MySQL 8.4.0, the deprecated mysql_native_password authentication plugin is no longer enabled by default. To enable it, start the server with --mysql-native-password=ON (added in MySQL 8.4.0), or by including mysql_native_password=ON in the [mysqld] section of your MySQL configuration file (added in MySQL 8.4.0). 
[Source](https://dev.mysql.com/doc/refman/8.4/en/mysql-nutshell.html)